### PR TITLE
Address conflict with Magento_Swatches LayeredNavigation plugin.

### DIFF
--- a/Block/FilterRenderer.php
+++ b/Block/FilterRenderer.php
@@ -8,24 +8,22 @@
 namespace Emizentech\Priceslider\Block;
 
 use Magento\Catalog\Model\Layer\Filter\FilterInterface;
-use Magento\Framework\View\Element\Template;
-use Magento\LayeredNavigation\Block\Navigation\FilterRendererInterface;
 
-class FilterRenderer extends Template implements FilterRendererInterface
+class FilterRenderer extends \Magento\LayeredNavigation\Block\Navigation\FilterRenderer
 {
     /**
      * @param FilterInterface $filter
      * @return string
      */
     public function render(FilterInterface $filter)
-    {	
+    {
         $this->assign('filterItems', $filter->getItems());
         $this->assign('filter' , $filter);
         $html = $this->_toHtml();
         $this->assign('filterItems', []);
         return $html;
     }
-    
+
     public function getPriceRange($filter){
     	$Filterprice = array('min' => 0 , 'max'=>0);
     	if($filter->getName() == 'Price' ){
@@ -35,7 +33,7 @@ class FilterRenderer extends Template implements FilterRendererInterface
     	}
     	return $Filterprice;
     }
-    
+
     public function getFilterUrl($filter){
     		$query = ['price'=> ''];
     	 return $this->getUrl('*/*/*', ['_current' => true, '_use_rewrite' => true, '_query' => $query]);

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/ObjectManager/etc/config.xsd">
     <preference for="Magento\LayeredNavigation\Block\Navigation\FilterRenderer" type="Emizentech\Priceslider\Block\FilterRenderer" />
+    <type name="Emizentech\Priceslider\Block\FilterRenderer">
+        <plugin name="swatches_layered_renderer" type="Magento\Swatches\Model\Plugin\FilterRenderer" sortOrder="1" />
+    </type>
 </config>


### PR DESCRIPTION
Currently, when you enable the Price Slider module, it disables the Magento_Swatches plugin for the LayeredNavigation. These changes address this problem, so that you can use the price slider without losing the swatches.
