### PR TITLE
Don't use store label in translation

### DIFF
--- a/view/frontend/templates/filter.phtml
+++ b/view/frontend/templates/filter.phtml
@@ -18,7 +18,7 @@
 
 
 ?>
-<?php if($filter->getName() == 'Price' ):?>
+<?php if($filter instanceof Magento\CatalogSearch\Model\Layer\Filter\Price ):?>
 <?php $range =  $this->getPriceRange($filter);?>
 <?php $url = $this->getFilterUrl($filter);?>
 <?php //var_dump($url);?>


### PR DESCRIPTION
Don't use store label to determine if the filter is a price filter. Instead check if the instance matches the class.
Fixes https://github.com/emizentech/magento2-price-slider/issues/3
